### PR TITLE
Use .length() for length calculation in c

### DIFF
--- a/cpp/sequel.cpp
+++ b/cpp/sequel.cpp
@@ -174,11 +174,7 @@ void bindStatement(sqlite3_stmt *statement, jsi::Runtime &rt, jsi::Value const &
       string strVal = value.asString(rt).utf8(rt);
       const char *cString = strVal.c_str();
 
-      int len = 0;
-      while (*cString)
-        len += (*cString++ & 0xc0) != 0x80;
-
-      sqlite3_bind_text(statement, ii + 1, strVal.c_str(), len, SQLITE_TRANSIENT);
+      sqlite3_bind_text(statement, ii + 1, cString, strlen(cString), SQLITE_TRANSIENT);
     }
   }
 }

--- a/cpp/sequel.cpp
+++ b/cpp/sequel.cpp
@@ -172,9 +172,8 @@ void bindStatement(sqlite3_stmt *statement, jsi::Runtime &rt, jsi::Value const &
     else if (value.isString())
     {
       string strVal = value.asString(rt).utf8(rt);
-      const char *cString = strVal.c_str();
 
-      sqlite3_bind_text(statement, ii + 1, cString, strlen(cString), SQLITE_TRANSIENT);
+      sqlite3_bind_text(statement, ii + 1, strVal.c_str(), strVal.length(), SQLITE_TRANSIENT);
     }
   }
 }

--- a/example/src/Database.ts
+++ b/example/src/Database.ts
@@ -16,11 +16,11 @@ export const createDb = async () => {
   const userRepository = getRepository(User);
 
   const user1 = new User();
-  user1.name = 'John Seedman';
+  user1.name = 'John Seedman 🤯';
   user1.age = 30;
   user1.networth = 30000.23;
-  user1.metadata = { 
-    nickname: "<p>We deliver that something because <em>some interesting text!</em></p>\n<p>Always remember...  </p>\n<p><strong>some text here.</strong></p>\n"
+  user1.metadata = {
+    nickname: "<p>We deliver that something because <em>some interesting text!</em></p>\n<p>Always remember...  </p>\n<p><strong>some 🧟‍♀️ 🧚 🍉 text here.</strong></p>\n"
   }
 
   // const book1 = new Book();


### PR DESCRIPTION
Fixes #3 

Using `.length()` calculates the correct amount of length for strings when inserting into SQLite database. This fixes the unicode encoding issue.

`.length()` from the cpp string class is a bit faster since it's already cached in the instance when initialized, so no need to recalculate it.