### PR TITLE
[Proposal]: SQL Loader Feature

### DIFF
--- a/cpp/SequelResult.h
+++ b/cpp/SequelResult.h
@@ -28,3 +28,10 @@ struct SequelResult
   string message;
   jsi::Value value;
 };
+
+struct SequelLiteralUpdateResult
+{
+  ResultType type;
+  string message;
+  int affectedRows;
+};

--- a/cpp/react-native-quick-sqlite.cpp
+++ b/cpp/react-native-quick-sqlite.cpp
@@ -221,6 +221,7 @@ void installSequel(jsi::Runtime &rt, const char *docPath)
             res.setProperty(rt, "commands", jsi::Value(commands));
             return move(res);
           } catch (...) {
+            sqFile.close();
             sequel_execute_literal_update(dbName, "ROLLBACK");
             jsi::detail::throwJSError(rt, "Unexpected error, transaction was rolledback");
             return {};

--- a/cpp/sequel.cpp
+++ b/cpp/sequel.cpp
@@ -414,7 +414,7 @@ SequelResult sequel_execute(jsi::Runtime &rt, string const dbName, string const 
   jsi::Object res = jsi::Object(rt);
   res.setProperty(rt, "rows", move(rows));
 
-  int changedRowCount = sqlite3_total_changes(db);
+  int changedRowCount = sqlite3_changes(db);
   res.setProperty(rt, "rowsAffected", jsi::Value(changedRowCount));
 
   // row id has nothing to do with the actual uuid/id of the object, but internal row count
@@ -428,4 +428,80 @@ SequelResult sequel_execute(jsi::Runtime &rt, string const dbName, string const 
       SequelResultOk,
       "",
       move(res)};
+}
+
+SequelLiteralUpdateResult sequel_execute_literal_update(string const dbName, string const &query) 
+{
+  // Check if db connection is opened
+  if (dbMap.count(dbName) == 0)
+  {
+    return {
+        SequelResultError,
+        "[react-native-quick-sqlite] Database not opened: " + dbName,
+        0
+    };
+  }
+
+  sqlite3 *db = dbMap[dbName];
+
+  // SQLite statements need to be compiled before executed
+  sqlite3_stmt *statement;
+
+  // Compile and move result into statement memory spot
+  int statementStatus = sqlite3_prepare_v2(db, query.c_str(), -1, &statement, NULL);
+
+  if (statementStatus != SQLITE_OK) // statemnet is correct, bind the passed parameters
+  {
+    const char *message = sqlite3_errmsg(db);
+    return {
+        SequelResultError,
+        "[react-native-quick-sqlite] SQL execution error: " + string(message),
+        0
+    };
+  }
+  
+  bool isConsuming = true;
+  bool isFailed = false;
+
+  int result, i, count, column_type;
+  string column_name;
+
+  while (isConsuming)
+  {
+    result = sqlite3_step(statement);
+
+    switch (result)
+    {
+      case SQLITE_ROW:
+        isConsuming = true;
+        break;
+
+      case SQLITE_DONE:
+        isConsuming = false;
+        break;
+
+      default:
+        isFailed = true;
+        isConsuming = false;
+    }
+  }
+
+  sqlite3_finalize(statement);
+
+  if (isFailed)
+  {
+    const char *message = sqlite3_errmsg(db);
+    return {
+        SequelResultError,
+        "[react-native-quick-sqlite] SQL execution error: " + string(message),
+        0
+    };
+  }
+
+  int changedRowCount = sqlite3_changes(db);
+  return {
+      SequelResultOk,
+      "",
+      changedRowCount
+  };
 }

--- a/cpp/sequel.h
+++ b/cpp/sequel.h
@@ -24,3 +24,5 @@ SequelResult sequel_remove(string const dbName, string const docPath);
 //SequelResult sequel_attach(string const &dbName);
 
 SequelResult sequel_execute(jsi::Runtime &rt, string const dbName, string const &query, jsi::Value const &params);
+
+SequelLiteralUpdateResult sequel_execute_literal_update(string const dbName, string const &query);

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,14 @@ interface QueryResult {
     item: (idx: number) => any;
   };
 }
+
+interface BulkupdateResult {
+  rowsAffected?: number;
+  commands?: number;
+  message?: string;
+  status?: 0 | 1;
+}
+
 interface ISQLite {
   open: (dbName: string, location?: string) => any;
   close: (dbName: string) => any;
@@ -39,6 +47,7 @@ interface ISQLite {
     query: string,
     params: any[] | undefined
   ) => QueryResult;
+  loadSqlFile: (dbName: string, location: string) => BulkupdateResult;
   // backgroundExecuteSql: (dbName: string, query: string, params: any[]) => any;
 }
 
@@ -58,6 +67,7 @@ interface IDBConnection {
     fail: (msg: string) => void
   ) => void;
   close: (ok: (res: any) => void, fail: (msg: string) => void) => void;
+  loadSqlFile: (location: string, callback: (result: BulkupdateResult) => void ) => void;
 }
 
 export const openDatabase = (
@@ -97,6 +107,12 @@ export const openDatabase = (
           fail(e);
         }
       },
+      loadSqlFile: (location: string, callback: (result: BulkupdateResult) => void) => {
+        const result = sqlite.loadSqlFile(options.name, location);
+        if (callback) {
+          callback(result);
+        }
+      }
     };
 
     ok(connection);


### PR DESCRIPTION
Hi @ospfranco . How are you?
I've made some tests in order to find better ways to handle large bulk operations, and I wanna know if you have any interest in a way to "import sql files" directly from the native code:

 - This feature allows fast "import" of SQL Files directly
   from a absolute path, on the C++ code, avoiding parsing
   large jsons or files via JavaScript in order to dispach
   calls to library. Some tests with datasets ~120k rows
   shows an improvment of at least 35% over the bulk update
   feature (PR 24).
 - Small bugfix on the "rowsAffected" property, that was
   collecting all changes on database instance since its
   opening instead of the current statement.