### PR TITLE
Resultset metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,11 @@ interface QueryResult {
     _array: any[];
     /** The lengh of the dataset */
     length: number;
-    /** A convenience function to acess the index based the row object
-     * @param idx the row index
-     * @returns the row structure identified by column names
-     */
-    item: (idx: number) => any;
   };
   /**
    * Query metadata, avaliable only for select query results
    */
-  metadata?: ResultsetMetadata;
+  metadata?: ColumnMetadata[];
 }
 
 /**
@@ -67,11 +62,6 @@ declare type ColumnMetadata = {
    * The index for this column for this resultset*/
   columnIndex: number;
 };
-
-/**
- * Collection of columns that represents the resultset of a query
- */
-declare type ResultsetMetadata = ColumnMetadata[];
 
 interface BatchQueryResult {
   status?: 0 | 1;
@@ -151,7 +141,7 @@ if (!result.status) {
 ```
 
 In some scenarios, dynamic applications may need to get some metadata information about the returned resultset.
-This can be done testing the returned data directly, but in some cases may not be enought, like when data is stored outside
+This can be done testing the returned data directly, but in some cases may not be enough, like when data is stored outside
 storage datatypes, like booleans or datetimes. When fetching data directly from tables or views linked to table columns, SQLite is able
 to identify the table declared types:
 

--- a/cpp/JSIHelper.h
+++ b/cpp/JSIHelper.h
@@ -87,6 +87,16 @@ struct SequelBatchOperationResult
 };
 
 /**
+ * Describe column information of a resultset
+ */
+struct QuickColumnMetadata
+{
+  string colunmName;
+  int columnIndex;
+  string columnDeclaredType;
+};
+
+/**
  * Fill the target vector with parsed parameters
  * */
 void jsiQueryArgumentsToSequelParam(jsi::Runtime &rt, jsi::Value const &args, vector<QuickValue> *target);
@@ -99,6 +109,6 @@ QuickValue createIntegerQuickValue(double value);
 QuickValue createInt64QuickValue(long long value);
 QuickValue createDoubleQuickValue(double value);
 QuickValue createArrayBufferQuickValue(uint8_t *arrayBufferValue, size_t arrayBufferSize);
-jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult status, vector<map<string, QuickValue>> *results);
+jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult status, vector<map<string, QuickValue>> *results, vector<QuickColumnMetadata> *metadata);
 
 #endif /* JSIHelper_h */

--- a/cpp/sqlbatchexecutor.cpp
+++ b/cpp/sqlbatchexecutor.cpp
@@ -60,7 +60,7 @@ SequelBatchOperationResult executeBatch(std::string dbName, vector<QuickQueryArg
     for(int i = 0; i<commandCount; i++) {
       auto command = commands->at(i);
       // We do not provide a datastructure to receive query data because we don't need/want to handle this results in a batch execution
-      auto result = sqliteExecute(dbName, command.sql, command.params.get(), NULL);
+      auto result = sqliteExecute(dbName, command.sql, command.params.get(), NULL, NULL);
       if(result.type == SQLiteError)
       {
         return SequelBatchOperationResult {

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -21,6 +21,6 @@ SQLiteOPResult sqliteRemoveDb(string const dbName, string const docPath);
 
 // SequelResult sequel_attach(string const &dbName);
 
-SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<QuickValue> *values, vector<map<string, QuickValue>> *result);
+SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<QuickValue> *values, vector<map<string, QuickValue>> *result, vector<QuickColumnMetadata> *metadata);
 
 SequelLiteralUpdateResult sqliteExecuteLiteral(string const dbName, string const &query);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ interface QueryResult {
   /**
    * Query metadata, avaliable only for select query results
    */
-  metadata?: ResultsetMetadata;
+  metadata?: ColumnMetadata[];
 }
 
 /**
@@ -59,11 +59,6 @@ declare type ColumnMetadata = {
    * The index for this column for this resultset*/
   columnIndex: number;
 };
-
-/**
- * Collection of columns that represents the resultset of a query
- */
-declare type ResultsetMetadata = ColumnMetadata[];
 
 /**
  * Allows the execution of bulk of sql commands

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,30 @@ interface QueryResult {
      */
     item: (idx: number) => any;
   };
+  /**
+   * Query metadata, avaliable only for select query results
+   */
+  metadata?: ResultsetMetadata;
 }
+
+/**
+ * Column metadata
+ * Describes some information about columns fetched by the query
+ */
+declare type ColumnMetadata = {
+  /** The name used for this column for this resultset */
+  columnName: string;
+  /** The declared column type for this column, when fetched directly from a table or a View resulting from a table column. "UNKNOWN" for dynamic values, like function returned ones. */
+  columnDeclaredType: string;
+  /**
+   * The index for this column for this resultset*/
+  columnIndex: number;
+};
+
+/**
+ * Collection of columns that represents the resultset of a query
+ */
+declare type ResultsetMetadata = ColumnMetadata[];
 
 /**
  * Allows the execution of bulk of sql commands


### PR DESCRIPTION
 - Feature to return resultset metadata on the low level API
   to help dynamic applications to analise column declared data types
   that can be "different" from storage datatypes, like datetime or booleans