### PR TITLE
Little change on Transaction API and Method enhance fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-quick-sqlite",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "description": "Fast SQLite for react-native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,8 +248,8 @@ sqlite.transaction = (dbName: string, callback: (tx: Transaction) => void) => {
   const txObject = new TransactionObjectImpl(dbName);
   const tx: PendingTransaction = {
     start: () => {
-      sqlite.executeSql(dbName, 'BEGIN TRANSACTION', null);
       try {
+        sqlite.executeSql(dbName, 'BEGIN TRANSACTION', null);
         callback(txObject);
         sqlite.executeSql(dbName, 'COMMIT', null);
       } catch (e: any) {


### PR DESCRIPTION
A little change to Transaction API in order to remove the boolean return requirement.
A small fix to ensure that a failed transaction will not cause next transaction on the queue to be called.
A small fix that enhance the rows object to contain the "item" function that is described in their returned object documentation (QueryResult). It's only present in sqlexecution produced by IDBConnection implementation.