### PR TITLE
Enable SQL Feature: SQL Attach and Dettach

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,7 @@ Note: You don't need to detach an attached database before closing your connecti
 will dettach any dettached databases.
 SQLite have a limit for attached databases: A default of 10, and a global max of 125
 
-Ref: 
-https://www.sqlite.org/lang_attach.html
-https://www.sqlite.org/lang_detach.html
+References: [Attach](https://www.sqlite.org/lang_attach.html) - [Detach](https://www.sqlite.org/lang_detach.html)
 
 ```ts
 const result = sqlite.attach('mainDatabase', 'statistics', 'stats', '../databases',);

--- a/README.md
+++ b/README.md
@@ -281,6 +281,12 @@ if(!result.status) {
   if(!data.status) {}
 }
 
+// You can detach databases at any moment
+const detachResult = sqlite.detach('mainDatabase', 'stats');
+if(!detachResult.status) {
+  // Database dettached
+}
+
 ```
 
 ## Use built-in SQLite

--- a/README.md
+++ b/README.md
@@ -27,11 +27,20 @@ Inspired/compatible with [react-native-sqlite-storage](https://github.com/andpor
 ## API
 
 ```typescript
-interface QueryResult {
-  status?: 0 | 1; // 0 for correct execution
+/**
+ * All SQLIte command results will have at least this status definition:
+ * Specific statments or actions can bring more data, relative to its context
+ * status: 0 or undefined for correct execution, 1 for error
+ *  message: if status === 1, here you will find error description
+ */
+export interface StatementResult {
+  status?: 0 | 1;
+  message?: string;
+}
+
+interface QueryResult extends StatementResult {
   insertId?: number;
   rowsAffected: number;
-  message?: string;
   rows?: {
     /** Raw array with all dataset */
     _array: any[];
@@ -55,16 +64,34 @@ interface ColumnMetadata = {
   columnIndex: number;
 };
 
-interface BatchQueryResult {
-  status?: 0 | 1;
+/**
+ * status: 0 or undefined for correct execution, 1 for error
+ * message: if status === 1, here you will find error description
+ * rowsAffected: Number of affected rows if status == 0
+ */
+export interface BatchQueryResult extends StatementResult {
   rowsAffected?: number;
-  message?: string;
+}
+
+/**
+ * Result of loading a file and executing every line as a SQL command
+ * Similar to BatchQueryResult
+ */
+export interface FileLoadResult extends BatchQueryResult {
+  commands?: number;
 }
 
 interface ISQLite {
-  open: (dbName: string, location?: string) => { status: 0 | 1 };
-  close: (dbName: string) => { status: 0 | 1 };
-  delete: (dbName: string, location?: string) => { status: 0 | 1 };
+  open: (dbName: string, location?: string) => StatementResult;
+  close: (dbName: string) => StatementResult;
+  delete: (dbName: string, location?: string) => StatementResult;
+  attach: (
+    mainDbName: string,
+    dbNameToAttach: string,
+    alias: string,
+    location?: string
+  ) => StatementResult;
+  detach: (mainDbName: string, alias: string) => StatementResult;
   executeSql: (
     dbName: string,
     query: string,
@@ -227,6 +254,33 @@ sqlite.asyncExecuteSql(
     }
   }
 );
+```
+
+### Attach or Detach another databases
+
+SQLite supports to attach or detach another database files into your main database connection through an alias.
+You can do any operation you like on this attached databases like JOIN results across tables in different schemas, or update data or objects.
+This databases can have different configurations, like journal modes, cache settings.
+
+You can, at any moment detach a database that you don't need anymore.
+Note: You don't need to detach an attached database before closing your connection. Closing the main connection
+will dettach any dettached databases.
+SQLite have a limit for attached databases: A default of 10, and a global max of 125
+
+Ref: 
+https://www.sqlite.org/lang_attach.html
+https://www.sqlite.org/lang_detach.html
+
+```ts
+const result = sqlite.attach('mainDatabase', 'statistics', 'stats', '../databases',);
+
+// Database is attached sucefully
+if(!result.status) {
+  const data = sqlite.executeSql('mainDatabase', 'SELECT * FROM some_table_from_mainschema a INNER JOIN stats.some_table b on a.id_column = b.id_column');
+  // Consume the results
+  if(!data.status) {}
+}
+
 ```
 
 ## Use built-in SQLite

--- a/cpp/installer.cpp
+++ b/cpp/installer.cpp
@@ -85,13 +85,13 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
         return createOk(rt);
       });
 
-  auto attachDatabase = jsi::Function::createFromHostFunction(
+  auto attach = jsi::Function::createFromHostFunction(
       rt,
-      jsi::PropNameID::forAscii(rt, "attachDatabase"),
+      jsi::PropNameID::forAscii(rt, "attach"),
       4,
       [](jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
           if(count < 3) {
-            return createError(rt, "[react-native-quick-sqlite][attachDatabase] Incorrect number of arguments");
+            return createError(rt, "[react-native-quick-sqlite][attach] Incorrect number of arguments");
           }
           if (!args[0].isString() || !args[1].isString() || !args[2].isString())
           {
@@ -104,7 +104,7 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
           {
             if (!args[3].isString())
             {
-              return createError(rt, "[react-native-quick-sqlite][attachDatabase] database location must be a string");
+              return createError(rt, "[react-native-quick-sqlite][attach] database location must be a string");
             }
 
             tempDocPath = tempDocPath + "/" + args[3].asString(rt).utf8(rt);
@@ -123,13 +123,13 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
           return createOk(rt);
       });
 
-  auto detachDatabase = jsi::Function::createFromHostFunction(
+  auto detach = jsi::Function::createFromHostFunction(
       rt,
-      jsi::PropNameID::forAscii(rt, "detachDatabase"),
+      jsi::PropNameID::forAscii(rt, "detach"),
       2,
       [](jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
           if(count < 2) {
-            return createError(rt, "[react-native-quick-sqlite][detachDatabase] Incorrect number of arguments");
+            return createError(rt, "[react-native-quick-sqlite][detach] Incorrect number of arguments");
           }
           if (!args[0].isString() || !args[1].isString())
           {
@@ -488,8 +488,8 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
   // Callable properties
   module.setProperty(rt, "open", move(open));
   module.setProperty(rt, "close", move(close));
-  module.setProperty(rt, "attach", move(attachDatabase));
-  module.setProperty(rt, "detach", move(detachDatabase));
+  module.setProperty(rt, "attach", move(attach));
+  module.setProperty(rt, "detach", move(detach));
   module.setProperty(rt, "delete", move(remove));
   module.setProperty(rt, "executeSql", move(execSQL));
   module.setProperty(rt, "asyncExecuteSql", move(asyncExecSQL));

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -130,29 +130,44 @@ SQLiteOPResult sqliteCloseDb(string const dbName)
   };
 }
 
-// SequelResult sequel_attach(string const &dbName)
-//{
-//     if(dbMap.count(dbName) == 0){
-//         cout << "[react-native-quick-sqlite]: DB " << dbName << " not open" << endl;
-//         return SequelResult{
-//             SequelResultError,
-//             dbName + " is not open",
-//             jsi::Value::undefined()
-//         };
-//     }
+SQLiteOPResult sqliteAttachDb(string const mainDBName, string const docPath, string const databaseToAttach, string const alias)
+{
+  /**
+   * There is no need to check if mainDBName is opened because sqliteExecuteLiteral will do that.
+   * */
+  string dbPath = get_db_path(databaseToAttach, docPath);
+  string statement = "ATTACH DATABASE '" + dbPath + "' AS " + alias;
+  SequelLiteralUpdateResult result = sqliteExecuteLiteral(mainDBName, statement);
+  if (result.type == SQLiteError)
+  {
+    return SQLiteOPResult{
+        .type = SQLiteError,
+        .errorMessage = mainDBName + " was unable to attach another database: " + string(result.message),
+      };
+  }
+  return SQLiteOPResult{
+      .type = SQLiteOk,
+  };
+}
 
-// TODO: What does "Attach" do? is it really necessary?
-// https://github.com/andpor/react-native-sqlite-storage/blob/master/platforms/ios/SQLite.m#L362
-
-//    NSString* sql = [NSString stringWithFormat:@"ATTACH DATABASE '%@' AS %@", dbPathToAttach, dbAlias];
-//
-//            if(sqlite3_exec(db, [sql UTF8String], NULL, NULL, NULL) == SQLITE_OK) {
-//              pluginResult = [SQLiteResult resultWithStatus:SQLiteStatus_OK messageAsString:@"Database attached successfully."];
-//            } else {
-//              pluginResult = [SQLiteResult resultWithStatus:SQLiteStatus_ERROR messageAsString:@"Unable to attach DB"];
-//            }
-
-//}
+SQLiteOPResult sqliteDetachDb(string const mainDBName, string const alias)
+{
+  /**
+   * There is no need to check if mainDBName is opened because sqliteExecuteLiteral will do that.
+   * */
+  string statement = "DETACH DATABASE " + alias;
+  SequelLiteralUpdateResult result = sqliteExecuteLiteral(mainDBName, statement);
+  if (result.type == SQLiteError)
+  {
+    return SQLiteOPResult{
+        .type = SQLiteError,
+        .errorMessage = mainDBName + "was unable to detach database: " + string(result.message),
+      };
+  }
+  return SQLiteOPResult{
+      .type = SQLiteOk,
+  };
+}
 
 SQLiteOPResult sqliteRemoveDb(string const dbName, string const docPath)
 {

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -19,7 +19,9 @@ SQLiteOPResult sqliteCloseDb(string const dbName);
 
 SQLiteOPResult sqliteRemoveDb(string const dbName, string const docPath);
 
-// SequelResult sequel_attach(string const &dbName);
+SQLiteOPResult sqliteAttachDb(string const mainDBName, string const docPath, string const databaseToAttach, string const alias);
+
+SQLiteOPResult sqliteDetachDb(string const mainDBName, string const alias);
 
 SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<QuickValue> *values, vector<map<string, QuickValue>> *result, vector<QuickColumnMetadata> *metadata);
 


### PR DESCRIPTION
Despite the fact that attach or dettach a database can be performed
sending a simple SQL Statement, its easier for the attach process to
let the driver resolve the database document directory in order to create
or attach a existing database file.

Attach a different database may allow some tweaks, like
using different WAL modes or synchronization for each database, or
allow a more granular vacuum strategy.