### PR TITLE
SQLite upgraded to version 3.39.2

### DIFF
--- a/cpp/sqlite3.h
+++ b/cpp/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.0"
-#define SQLITE_VERSION_NUMBER 3039000
-#define SQLITE_SOURCE_ID      "2022-06-25 14:57:57 14e166f40dbfa6e055543f8301525f2ca2e96a02a57269818b9e69e162e98918"
+#define SQLITE_VERSION        "3.39.2"
+#define SQLITE_VERSION_NUMBER 3039002
+#define SQLITE_SOURCE_ID      "2022-07-21 15:24:47 698edb77537b67c41adc68f9b892db56bcf9a55e00371a61420f3ddd668e6603"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -6282,7 +6282,7 @@ SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 **
 ** ^The sqlite3_db_name(D,N) interface returns a pointer to the schema name
 ** for the N-th database on database connection D, or a NULL pointer of N is
-** out of range.  An N alue of 0 means the main database file.  An N of 1 is
+** out of range.  An N value of 0 means the main database file.  An N of 1 is
 ** the "temp" schema.  Larger values of N correspond to various ATTACH-ed
 ** databases.
 **


### PR DESCRIPTION
Fix an incorrect result from a query that uses a view that contains a compound SELECT in which only one arm contains a RIGHT JOIN and where the view is not the first FROM clause term of the query that contains the view. [forum post 174afeae5734d42d](https://sqlite.org/forum/forumpost/174afeae5734d42d).
Fix some harmless compiler warnings.
Fix a long-standing problem with [ALTER TABLE RENAME](https://www.sqlite.org/lang_altertable.html#altertabrename) that can only arise if the [sqlite3_limit](https://www.sqlite.org/c3ref/limit.html)([SQLITE_LIMIT_SQL_LENGTH](https://www.sqlite.org/c3ref/c_limit_attached.html#sqlitelimitsqllength)) is set to a very small value.
Fix a long-standing problem in [FTS3](https://www.sqlite.org/fts3.html) that can only arise when compiled with the [SQLITE_ENABLE_FTS3_PARENTHESIS](https://www.sqlite.org/compile.html#enable_fts3_parenthesis) compile-time option.
Fix the build so that is works when the [SQLITE_DEBUG](https://www.sqlite.org/compile.html#debug) and [SQLITE_OMIT_WINDOWFUNC](https://www.sqlite.org/compile.html#omit_windowfunc) compile-time options are both provided at the same time.
Fix the initial-prefix optimization for the [REGEXP](https://www.sqlite.org/lang_expr.html#regexp) extension so that it works correctly even if the prefix contains characters that require a 3-byte UTF8 encoding.
Enhance the [sqlite_stmt](https://www.sqlite.org/stmt.html) virtual table so that it buffers all of its output.

Fix a performance regression in the query planner associated with rearranging the order of FROM clause terms in the presences of a LEFT JOIN.
Apply fixes for CVE-2022-35737, Chromium bugs 1343348 and 1345947, [forum post 3607259d3c](https://sqlite.org/forum/forumpost/3607259d3c), and other minor problems discovered by internal testing.