### PR TITLE
fix: made retrieving TEXT columns from SQLite with NULL values in-between strings work properly

### DIFF
--- a/cpp/JSIHelper.cpp
+++ b/cpp/JSIHelper.cpp
@@ -154,7 +154,8 @@ jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult sta
           QuickValue value = entry.second;
           if (value.dataType == TEXT)
           {
-            rowObject.setProperty(rt, columnName.c_str(), jsi::String::createFromUtf8(rt, value.textValue.c_str()));
+            // using value.textValue (std::string) directly allows jsi::String to use length property of std::string (allowing strings with NULLs in them like SQLite does)
+            rowObject.setProperty(rt, columnName.c_str(), jsi::String::createFromUtf8(rt, value.textValue));
           }
           else if (value.dataType == INTEGER)
           {

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -329,7 +329,9 @@ SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<Qu
         case SQLITE_TEXT:
         {
           const char *column_value = reinterpret_cast<const char *>(sqlite3_column_text(statement, i));
-          row[column_name] = createTextQuickValue(string(column_value));
+          int byteLen = sqlite3_column_bytes(statement, i);
+          // Specify length too; in case string contains NULL in the middle (which SQLite supports!)
+          row[column_name] = createTextQuickValue(string(column_value, byteLen));
           break;
         }
 


### PR DESCRIPTION
These minor patches allow strings with NULL inside them to work properly in SQLite (like they do natively).

Currently, with NULL characters in-between strings (previously not possible in JavascriptCore due to a bug, but is functioning properly in Hermes engine), retrieving them would result in early truncation due to the way the `std::string`s were initialized at the locations addressed by the fix (initialized without length property).