### PR TITLE
exporting the interface for IDBConnection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ interface IConnectionOptions {
   location?: string; // not used, we are storing everything on the documents folder
 }
 
-interface IDBConnection {
+export interface IDBConnection {
   executeSql: (
     sql: string,
     args: any[],


### PR DESCRIPTION
This should help avoid ts(4023) errors when using the result of openDatabase in typescript