### PR TITLE
The library supports async methods, but does not handle threading iss…

### DIFF
--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -84,7 +84,7 @@ SQLiteOPResult sqliteOpenDb(string const dbName, string const docPath)
 {
   string dbPath = get_db_path(dbName, docPath);
 
-  int sqlOpenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+  int sqlOpenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
 
   sqlite3 *db;
   int exit = 0;


### PR DESCRIPTION
The library supports async methods, but does not handle threading issues properly while using sqlite, and a runtime error is thrown occasionally. I found this very hard to reproduce, but the error throws a log statement before a crash:

```
BUG IN CLIENT OF sqlite3.dylib: illegal multi-threaded access
```

According to the [SQLite thread-safe docs](https://www.sqlite.org/threadsafe.html), we can either use compiler flags or select upon runtime, the threading mode. There are three threading modes available:
* Single-thread
* Multi-thread - db can be used across multiple threads but connections cannot be shared
* Serialized - db and connections can be shared across threads

`react-native-quick-sqlite` offers both sync and async versions of the method, and we have a couple of choices:

1. We could leave it up to clients to define compile-time threading flags it requires...but if we do that, the sync or async methods need to be preprocessed out of the native and JS/TS code.

2. We could select runtime flags, but this would require passing in the correct flags for opening the db. This way, the user can choose to use async-only (SQLITE_OPEN_NOMUTEX), serialized (SQLITE_OPEN_FULLMUTEX), or single-thread.

Single-thread seems to be the default (assuming no other compiler flags are present). For this library's purpose, I think we should create an enum with these values and pass it as an optional into the sqlite opendb method:
* If no flags are present, use serialized mode (safest and db and connections can be shared across threads)
* If the user wants multi-threaded-no-share-connections or single-thread, they can choose one of those modes

Until the configurable solution is implemented (or another solution is presented/implemented), I think we should fix this by hard-coding `SQLITE_OPEN_FULLMUTEX` in the openDb flags -- so the issue is fixed as things stand today.