### PR TITLE
feat(ios&android): Support specifying pre-processor flags to sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,37 @@ If you have an existing database file you want to load you can navigate from the
 
 Alternatively you can place/move your database file using the one of the many react-native fs libraries.
 
+## Enable compile-time options
+
+By specifying pre-processor flags, you can enable optional features like FTS5, Geopoly, etc.
+
+### iOS
+
+Add a `post_install` block to your `<PROJECT_ROOT>/ios/Podfile` like so:
+
+```ruby
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.name == "react-native-quick-sqlite" then
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '<SQLITE_FLAGS>']
+      end
+    end
+  end
+end
+```
+
+Replace the `<SQLITE_FLAGS>` part with flags you want to add.
+For example, you could add `SQLITE_ENABLE_FTS5=1` to `GCC_PREPROCESSOR_DEFINITIONS` to enable FTS5 in the iOS project.
+
+### Android
+
+You can specify flags via `<PROJECT_ROOT>/android/gradle.properties` like so:
+
+```
+quickSqliteFlags="<SQLITE_FLAGS>"
+```
+
 ## More
 
 If you want to learn how to make your own JSI module buy my [JSI/C++ cheat sheet](http://ospfranco.gumroad.com/).

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -56,6 +56,10 @@ add_library(
   cpp-adapter.cpp
 )
 
+add_definitions(
+  ${SQLITE_FLAGS}
+)
+
 # find fbjni package
 file (GLOB LIBFBJNI_INCLUDE_DIR "${BUILD_DIR}/fbjni-*-headers.jar/")
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ def rnMinorVersion = Integer.parseInt(minor)
 def reactProperties = new Properties()
 file("$nodeModules/react-native/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\.")[1].toInteger()
+def SQLITE_FLAGS = rootProject.properties['quickSqliteFlags']
 
 android {
   
@@ -72,7 +73,8 @@ android {
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             arguments '-DANDROID_STL=c++_shared',
               "-DREACT_NATIVE_VERSION=${REACT_NATIVE_VERSION}",
-              "-DNODE_MODULES_DIR=${nodeModules}"
+              "-DNODE_MODULES_DIR=${nodeModules}",
+              "-DSQLITE_FLAGS='${SQLITE_FLAGS ? SQLITE_FLAGS : ''}'"
         }
     }
     


### PR DESCRIPTION
I've managed to enable FTS5 on both iOS and Android by specifying pre-processor flags.

On Android, we need to accept a setting from the parent project.
This PR makes it possible to specify SQLite flags via `android/gradle.properties`.

Also, I've added instructions on how to do that for iOS and Android.
Maybe the grammar could be improved tho.

fix #37