### PR TITLE
Don't allow partial transactions to commit

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -228,7 +228,7 @@ PODS:
   - React-jsinspector (0.67.4)
   - React-logger (0.67.4):
     - glog
-  - react-native-quick-sqlite (5.0.2):
+  - react-native-quick-sqlite (5.0.3):
     - React
     - React-callinvoker
     - React-Core
@@ -431,7 +431,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: cbdf37cebdc4f5d8b3d0bf5ccaa6147fd9de9f3d
   React-jsinspector: f4775ea9118cbe1f72b834f0f842baa7a99508d8
   React-logger: a1f028f6d8639a3f364ef80419e5e862e1115250
-  react-native-quick-sqlite: 5758b99497db29264f8a254c40ea5ef4a5c4d557
+  react-native-quick-sqlite: f5d0bedfdbd587dd17d93ab28c38b0bda1525de5
   React-perflogger: 0afaf2f01a47fd0fc368a93bfbb5bd3b26db6e7f
   React-RCTActionSheet: 59f35c4029e0b532fc42114241a06e170b7431a2
   React-RCTAnimation: aae4f4bed122e78bdab72f7118d291d70a932ce2

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 // Swap imports to test the typeORM version
 import {
+  deleteUsers,
   lowLevelInit,
   queryUsers,
   testInsert,
@@ -33,6 +34,14 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Quick-SQLite Tester</Text>
+      <Button
+        title="Clear database"
+        color="red"
+        onPress={() => {
+          deleteUsers();
+          setUsers([]);
+        }}
+      />
       <Button
         title="Refresh"
         onPress={() => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,7 +17,11 @@ import {
   testInsert,
   executeFailingTypeORMQuery,
   testAsyncExecute,
+  testAsyncTransactionFailure,
+  testAsyncTransactionSuccess,
   testFailedAsync,
+  testTransactionFailure,
+  testTransactionSuccess,
 } from './Database';
 import type { User } from './model/User';
 import { Buffer } from 'buffer';
@@ -69,6 +73,48 @@ export default function App() {
         title="Create user async failure"
         onPress={() => {
           testFailedAsync();
+        }}
+      />
+      <HR />
+      <Text style={styles.sectionHeader}>Transactions</Text>
+      <Button
+        title="Create users"
+        onPress={() => {
+          testTransactionSuccess();
+          setTimeout(() => {
+            const users = queryUsers();
+            setUsers(users);
+          }, 1000);
+        }}
+      />
+      <Button
+        title="Create users failure"
+        onPress={() => {
+          testTransactionFailure();
+          setTimeout(() => {
+            const users = queryUsers();
+            setUsers(users);
+          }, 1000);
+        }}
+      />
+      <Button
+        title="Create users async"
+        onPress={() => {
+          testAsyncTransactionSuccess();
+          setTimeout(() => {
+            const users = queryUsers();
+            setUsers(users);
+          }, 1000);
+        }}
+      />
+      <Button
+        title="Create users async failure"
+        onPress={() => {
+          testAsyncTransactionFailure();
+          setTimeout(() => {
+            const users = queryUsers();
+            setUsers(users);
+          }, 1000);
         }}
       />
       <HR />
@@ -144,6 +190,12 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 20,
     color: 'black',
+  },
+  sectionHeader: {
+    alignSelf: 'center',
+    fontWeight: '400',
+    fontSize: 18,
+    marginVertical: 10,
   },
   text: {
     color: 'black',

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -40,8 +40,9 @@ export default function App() {
           setUsers(users);
         }}
       />
+      <HR />
       <Button
-        title="Create user (without transaction)"
+        title="Create user"
         onPress={() => {
           testInsert();
           const users = queryUsers();
@@ -49,29 +50,19 @@ export default function App() {
         }}
       />
       <Button
-        title="Failed transaction"
-        onPress={() => {
-          testFailedAsync();
-        }}
-      />
-      {/*
-      <Button
-        title="Create user (with transaction)"
-        onPress={() => {
-          testTransaction();
-          setTimeout(() => {
-            const users = queryUsers();
-            setUsers(users);
-          }, 1000);
-        }}
-      /> */}
-      <Button
-        title="Test async execute (transaction)"
+        title="Create user async"
         onPress={async () => {
           const users = await testAsyncExecute();
           setUsers(users);
         }}
       />
+      <Button
+        title="Create user async failure"
+        onPress={() => {
+          testFailedAsync();
+        }}
+      />
+      <HR />
       <Button
         title="Execute typeORM failing query"
         onPress={executeFailingTypeORMQuery}
@@ -102,17 +93,25 @@ export default function App() {
               <Text style={styles.name}>{item.name}</Text>
               <Text style={styles.text}>{item.age}</Text>
               <Text style={styles.text}>{item.networth}</Text>
-              {/* <Text>{item.metadata.nickname}</Text> */}
-              {/* <Text style={{ fontWeight: 'bold', marginTop: 10 }}>
-                Favorite Book
-              </Text>
-              <Text>{info.item.favoriteBook.title}</Text> */}
             </View>
           );
         }}
         keyExtractor={(item: any) => item.id}
       />
     </View>
+  );
+}
+
+function HR() {
+  return (
+    <View
+      style={{
+        borderBottomColor: '#333',
+        borderBottomWidth: 1,
+        marginHorizontal: 10,
+        marginVertical: 4,
+      }}
+    />
   );
 }
 
@@ -131,6 +130,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     fontWeight: '500',
     fontSize: 20,
+    marginVertical: 10,
   },
   name: {
     fontSize: 20,

--- a/example/src/Database.ts
+++ b/example/src/Database.ts
@@ -26,18 +26,6 @@ export const lowLevelInit = () => {
   }
 };
 
-export const testTransaction = () => {
-  // sqlite.transaction('test', (tx) => {
-  //   tx.executeSql(
-  //     'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?);',
-  //     [new Date().getMilliseconds(), `Jerry`, 45, 20.23]
-  //   );
-  //   console.warn('committing transaction');
-  //   // return true to commit transaction, false to revert
-  //   return true;
-  // });
-};
-
 export const testInsert = () => {
   // Basic request
   db.execute(

--- a/example/src/Database.ts
+++ b/example/src/Database.ts
@@ -26,6 +26,10 @@ export const lowLevelInit = () => {
   }
 };
 
+export const deleteUsers = () => {
+  db.execute('delete from User');
+};
+
 export const testInsert = () => {
   // Basic request
   db.execute(

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
-    "pods": "cd example && pod-install --quiet",
+    "pods": "cd example && npx pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods",
     "bump": "./bump-version.sh"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,11 @@ QuickSQLite.transaction = (
 
   // Local transaction context object implementation
   const execute = (query: string, params?: any[]): QueryResult => {
+    if (locks[dbName].isFinalized) {
+      throw Error(
+        `Quick SQLite Error: Cannot execute query on finalized transaction: ${dbName}`
+      );
+    }
     return QuickSQLite.execute(dbName, query, params);
   };
 
@@ -286,10 +291,20 @@ QuickSQLite.transactionAsync = (
 
   // Local transaction context object implementation
   const execute = (query: string, params?: any[]): QueryResult => {
+    if (locks[dbName].isFinalized) {
+      throw Error(
+        `Quick SQLite Error: Cannot execute query on finalized transaction: ${dbName}`
+      );
+    }
     return QuickSQLite.execute(dbName, query, params);
   };
 
   const executeAsync = (query: string, params?: any[] | undefined) => {
+    if (locks[dbName].isFinalized) {
+      throw Error(
+        `Quick SQLite Error: Cannot execute query on finalized transaction: ${dbName}`
+      );
+    }
     return QuickSQLite.executeAsync(dbName, query, params);
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,15 +237,23 @@ QuickSQLite.transaction = (
     return QuickSQLite.execute(dbName, query, params);
   };
 
+  const commit = () => {
+    return QuickSQLite.execute(dbName, 'COMMIT');
+  };
+
+  const rollback = () => {
+    return QuickSQLite.execute(dbName, 'ROLLBACK');
+  };
+
   const tx: PendingTransaction = {
     start: () => {
       try {
         QuickSQLite.execute(dbName, 'BEGIN TRANSACTION');
         callback({ execute });
 
-        QuickSQLite.execute(dbName, 'COMMIT');
+        commit();
       } catch (e: any) {
-        QuickSQLite.execute(dbName, 'ROLLBACK');
+        rollback();
         throw e;
       } finally {
         locks[dbName].inProgress = false;
@@ -275,6 +283,14 @@ QuickSQLite.transactionAsync = (
     return QuickSQLite.executeAsync(dbName, query, params);
   };
 
+  const commit = () => {
+    return QuickSQLite.execute(dbName, 'COMMIT');
+  };
+
+  const rollback = () => {
+    return QuickSQLite.execute(dbName, 'ROLLBACK');
+  };
+
   const tx: PendingTransaction = {
     start: async () => {
       try {
@@ -284,9 +300,9 @@ QuickSQLite.transactionAsync = (
           executeAsync,
         });
 
-        QuickSQLite.execute(dbName, 'COMMIT');
+        commit();
       } catch (e: any) {
-        QuickSQLite.execute(dbName, 'ROLLBACK');
+        rollback();
         throw e;
       } finally {
         locks[dbName].inProgress = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ QuickSQLite.transaction = (
         throw e;
       } finally {
         locks[dbName].inProgress = false;
-        locks[dbName].isFinalized = true;
+        locks[dbName].isFinalized = false;
         startNextTransaction(dbName);
       }
     },
@@ -345,7 +345,7 @@ QuickSQLite.transactionAsync = (
         throw e;
       } finally {
         locks[dbName].inProgress = false;
-        locks[dbName].isFinalized = true;
+        locks[dbName].isFinalized = false;
         startNextTransaction(dbName);
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,12 +110,16 @@ export interface FileLoadResult extends BatchQueryResult {
 }
 
 export interface Transaction {
+  commit: () => QueryResult;
   execute: (query: string, params?: any[]) => QueryResult;
+  rollback: () => QueryResult;
 }
 
 export interface TransactionAsync {
+  commit: () => QueryResult;
   execute: (query: string, params?: any[]) => QueryResult;
   executeAsync: (query: string, params?: any[] | undefined) => Promise<any>;
+  rollback: () => QueryResult;
 }
 
 export interface PendingTransaction {
@@ -259,7 +263,7 @@ QuickSQLite.transaction = (
     start: () => {
       try {
         QuickSQLite.execute(dbName, 'BEGIN TRANSACTION');
-        callback({ execute });
+        callback({ commit, execute, rollback });
 
         if (!locks[dbName].isFinalized) {
           commit();
@@ -325,8 +329,10 @@ QuickSQLite.transactionAsync = (
       try {
         QuickSQLite.execute(dbName, 'BEGIN TRANSACTION');
         await callback({
+          commit,
           execute,
           executeAsync,
+          rollback,
         });
 
         if (!locks[dbName].isFinalized) {


### PR DESCRIPTION
This prevents partial transactions from committing.

Before this change, if a consuming application caught an error and didn't rethrow it (or a different error), the transaction would commit, leaving the consuming application to clean up bad data. This moves the `COMMIT` and `ROLLBACK` calls into the `finally` blocks for transactions so consuming applications can implement their own error handling and can't accidentally forget to throw an error if one is caught.

Note: the main change for this PR is 3c983cd. The commits leading to it add a missing development dependency and add prettier.

Closes #92.