### PR TITLE
Rollback added in case of SQL Error reported by SQLite API.

### DIFF
--- a/cpp/sqlbatchexecutor.cpp
+++ b/cpp/sqlbatchexecutor.cpp
@@ -63,6 +63,7 @@ SequelBatchOperationResult sqliteExecuteBatch(std::string dbName, vector<QuickQu
       auto result = sqliteExecute(dbName, command.sql, command.params.get(), NULL, NULL);
       if(result.type == SQLiteError)
       {
+        sqliteExecuteLiteral(dbName, "ROLLBACK");
         return SequelBatchOperationResult {
           .type = SQLiteError,
           .message = result.errorMessage,


### PR DESCRIPTION
Added missing transaction rollback in case of SQL command errors reported by SQLite API in the middle of a batch execution.

Related to
#96 