### PR TITLE
Add absolute path for location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ datasource = new DataSource({
 
 # Loading existing DBs
 
-The library creates/opens databases by appending the passed name plus, the [documents directory on iOS](https://github.com/ospfranco/react-native-quick-sqlite/blob/733e876d98896f5efc80f989ae38120f16533a66/ios/QuickSQLite.mm#L34-L35) and the [files directory on Android](https://github.com/ospfranco/react-native-quick-sqlite/blob/main/android/src/main/java/com/reactnativequicksqlite/QuickSQLiteBridge.java#L16), this differs from other SQL libraries (some place it in a `www` folder, some in androids `databases` folder, etc.).
+The library creates/opens databases by appending the passed name plus, the [documents directory on iOS](https://github.com/ospfranco/react-native-quick-sqlite/blob/733e876d98896f5efc80f989ae38120f16533a66/ios/QuickSQLite.mm#L34-L35) and the [files directory on Android](https://github.com/ospfranco/react-native-quick-sqlite/blob/main/android/src/main/java/com/reactnativequicksqlite/QuickSQLiteBridge.java#L16), this differs from other SQL libraries (some place it in a `www` folder, some in androids `databases` folder, etc.). You can also use absolute path(paths prefixed with '"/" or "file://").
 
 If you have an existing database file you want to load you can navigate from these directories using dot notation. e.g. `../www/myDb.sqlite`. Note that on iOS the file system is sand-boxed, so you cannot access files/directories not in your app bundle directories.
 

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -14,12 +14,16 @@ using namespace std;
 using namespace facebook;
 
 namespace osp {
-string docPathStr;
+string dbPathStr;
 std::shared_ptr<react::CallInvoker> invoker;
 
-void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker, const char *docPath)
+bool isAbsolutePath(const std::string& str) {
+    return (str.rfind("/", 0) == 0) || (str.rfind("file://", 0) == 0);
+}
+
+void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker, const char *dbPath)
 {
-  docPathStr = std::string(docPath);
+  dbPathStr = std::string(dbPath);
   auto pool = std::make_shared<ThreadPool>();
   invoker = jsCallInvoker;
 
@@ -35,7 +39,7 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
     }
 
     string dbName = args[0].asString(rt).utf8(rt);
-    string tempDocPath = string(docPathStr);
+    string tempDBPath = string(dbPathStr);
     if (count > 1 && !args[1].isUndefined() && !args[1].isNull())
     {
       if (!args[1].isString())
@@ -43,10 +47,11 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
         throw jsi::JSError(rt, "[react-native-quick-sqlite][open] database location must be a string");
       }
 
-      tempDocPath = tempDocPath + "/" + args[1].asString(rt).utf8(rt);
+      string location = args[1].asString(rt).utf8(rt);
+      tempDBPath = isAbsolutePath(location) ? location : tempDBPath + "/" + location;
     }
 
-    SQLiteOPResult result = sqliteOpenDb(dbName, tempDocPath);
+    SQLiteOPResult result = sqliteOpenDb(dbName, tempDBPath);
 
     if (result.type == SQLiteError)
     {
@@ -66,21 +71,21 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
       return {};
     }
 
-    string tempDocPath = string(docPathStr);
+    string tempDBPath = string(dbPathStr);
     if (count > 3 && !args[3].isUndefined() && !args[3].isNull())
     {
       if (!args[3].isString())
       {
         throw jsi::JSError(rt, "[react-native-quick-sqlite][attach] database location must be a string");
       }
-
-      tempDocPath = tempDocPath + "/" + args[3].asString(rt).utf8(rt);
+      string location = args[3].asString(rt).utf8(rt);
+      tempDBPath = isAbsolutePath(location) ? location : tempDBPath + "/" + location;
     }
 
     string dbName = args[0].asString(rt).utf8(rt);
     string databaseToAttach = args[1].asString(rt).utf8(rt);
     string alias = args[2].asString(rt).utf8(rt);
-    SQLiteOPResult result = sqliteAttachDb(dbName, tempDocPath, databaseToAttach, alias);
+    SQLiteOPResult result = sqliteAttachDb(dbName, tempDBPath, databaseToAttach, alias);
 
     if (result.type == SQLiteError)
     {
@@ -150,7 +155,7 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
 
     string dbName = args[0].asString(rt).utf8(rt);
 
-    string tempDocPath = string(docPathStr);
+    string tempDBPath = string(dbPathStr);
     if (count > 1 && !args[1].isUndefined() && !args[1].isNull())
     {
       if (!args[1].isString())
@@ -158,11 +163,12 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
         throw jsi::JSError(rt, "[react-native-quick-sqlite][open] database location must be a string");
       }
 
-      tempDocPath = tempDocPath + "/" + args[1].asString(rt).utf8(rt);
+      string location = args[1].asString(rt).utf8(rt);
+      tempDBPath = isAbsolutePath(location) ? location : tempDBPath + "/" + location;
     }
 
 
-    SQLiteOPResult result = sqliteRemoveDb(dbName, tempDocPath);
+    SQLiteOPResult result = sqliteRemoveDb(dbName, tempDBPath);
 
     if (result.type == SQLiteError)
     {


### PR DESCRIPTION
Added absolute path for `location` option.

For Base Example:

```js
const db = open('myDb.sqlite', '/Users/Library/Devices/Containers/Data/Application/Library');
```

For Typeorm Example:

```js
import { typeORMDriver } from 'react-native-quick-sqlite'

datasource = new DataSource({
  type: 'react-native',
  database: 'typeormdb',
  location: '/Users/Library/Devices/Containers/Data/Application/Library',
  driver: typeORMDriver,
  entities: [...],
  synchronize: true,
});
```

