### PR TITLE
Return a promise from transaction as per README and transaction error handling improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,12 @@ local.properties
 .cxx/
 example/.cxx/
 
-# Ruby / Cocoapods
+# Bundle
+#
+vendor/
+
+# Cocoapods
+#
 example/ios/Pods
 example/vendor/bundle
 

--- a/example/src/tests/rawQueries.spec.ts
+++ b/example/src/tests/rawQueries.spec.ts
@@ -119,13 +119,13 @@ export function registerBaseTests() {
       }
     });
 
-    it('Transaction, auto commit', done => {
+    it('Transaction, auto commit', async () => {
       const id = chance.integer();
       const name = chance.name();
       const age = chance.integer();
       const networth = chance.floating();
 
-      db.transaction(tx => {
+      await db.transaction(tx => {
         const res = tx.execute(
           'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
           [id, name, age, networth],
@@ -139,27 +139,24 @@ export function registerBaseTests() {
         expect(res.rows?.item).to.be.a('function');
       });
 
-      setTimeout(() => {
-        const res = db.execute('SELECT * FROM User');
-        expect(res.rows?._array).to.eql([
-          {
-            id,
-            name,
-            age,
-            networth,
-          },
-        ]);
-        done();
-      }, 200);
+      const res = db.execute('SELECT * FROM User');
+      expect(res.rows?._array).to.eql([
+        {
+          id,
+          name,
+          age,
+          networth,
+        },
+      ]);
     });
 
-    it('Transaction, manual commit', done => {
+    it('Transaction, manual commit', async () => {
       const id = chance.integer();
       const name = chance.name();
       const age = chance.integer();
       const networth = chance.floating();
 
-      db.transaction(tx => {
+      await db.transaction(tx => {
         const res = tx.execute(
           'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
           [id, name, age, networth],
@@ -175,27 +172,77 @@ export function registerBaseTests() {
         tx.commit();
       });
 
-      setTimeout(() => {
-        const res = db.execute('SELECT * FROM User');
-        expect(res.rows?._array).to.eql([
-          {
-            id,
-            name,
-            age,
-            networth,
-          },
-        ]);
-        done();
-      }, 200);
+      const res = db.execute('SELECT * FROM User');
+      expect(res.rows?._array).to.eql([
+        {
+          id,
+          name,
+          age,
+          networth,
+        },
+      ]);
     });
 
-    it('Transaction, cannot execute after commit', done => {
+    it('Transaction, executed in order', async () => {
+      // ARRANGE: Setup for multiple transactions
+      const iterations = 10;
+      const actual: unknown[] = [];
+
+      // ARRANGE: Generate expected data
+      const id = chance.integer();
+      const name = chance.name();
+      const age = chance.integer();
+
+      // ACT: Start multiple transactions to upsert and select the same record
+      const promises = [];
+      for (let iteration = 1; iteration <= iterations; iteration++) {
+        const promised = db.transaction(tx => {
+          // ACT: Upsert statement to create record / increment the value
+          tx.execute(
+            `
+              INSERT OR REPLACE INTO [User] ([id], [name], [age], [networth])
+              SELECT ?, ?, ?,
+                IFNULL((
+                  SELECT [networth] + 1000
+                  FROM [User]
+                  WHERE [id] = ?
+                ), 0)
+          `,
+            [id, name, age, id],
+          );
+
+          // ACT: Select statement to get incremented value and store it for checking later
+          const results = tx.execute(
+            'SELECT [networth] FROM [User] WHERE [id] = ?',
+            [id],
+          );
+
+          actual.push(results.rows?._array[0].networth);
+        });
+
+        promises.push(promised);
+      }
+
+      // ACT: Wait for all transactions to complete
+      await Promise.all(promises);
+
+      // ASSERT: That the expected values where returned
+      const expected = Array(iterations)
+        .fill(0)
+        .map((_, index) => index * 1000);
+      expect(actual).to.eql(
+        expected,
+        'Each transaction should read a different value',
+      );
+    });
+
+    it('Transaction, cannot execute after commit', async () => {
       const id = chance.integer();
       const name = chance.name();
       const age = chance.integer();
       const networth = chance.floating();
 
-      db.transaction(tx => {
+      await db.transaction(tx => {
         const res = tx.execute(
           'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
           [id, name, age, networth],
@@ -217,27 +264,24 @@ export function registerBaseTests() {
         }
       });
 
-      setTimeout(() => {
-        const res = db.execute('SELECT * FROM User');
-        expect(res.rows?._array).to.eql([
-          {
-            id,
-            name,
-            age,
-            networth,
-          },
-        ]);
-        done();
-      }, 1000);
+      const res = db.execute('SELECT * FROM User');
+      expect(res.rows?._array).to.eql([
+        {
+          id,
+          name,
+          age,
+          networth,
+        },
+      ]);
     });
 
-    it('Incorrect transaction, manual rollback', done => {
+    it('Incorrect transaction, manual rollback', async () => {
       const id = chance.string();
       const name = chance.name();
       const age = chance.integer();
       const networth = chance.floating();
 
-      db.transaction(tx => {
+      await db.transaction(tx => {
         try {
           tx.execute(
             'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
@@ -248,11 +292,8 @@ export function registerBaseTests() {
         }
       });
 
-      setTimeout(() => {
-        const res = db.execute('SELECT * FROM User');
-        expect(res.rows?._array).to.eql([]);
-        done();
-      }, 200);
+      const res = db.execute('SELECT * FROM User');
+      expect(res.rows?._array).to.eql([]);
     });
 
     it('Correctly throws', () => {
@@ -270,13 +311,13 @@ export function registerBaseTests() {
       }
     });
 
-    it('Rollback', done => {
+    it('Rollback', async () => {
       const id = chance.integer();
       const name = chance.name();
       const age = chance.integer();
       const networth = chance.floating();
 
-      db.transaction(tx => {
+      await db.transaction(tx => {
         tx.execute(
           'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
           [id, name, age, networth],
@@ -284,8 +325,59 @@ export function registerBaseTests() {
         tx.rollback();
         const res = db.execute('SELECT * FROM User');
         expect(res.rows?._array).to.eql([]);
-        done();
       });
+    });
+
+    it('Transaction, rejects on callback error', async () => {
+      const promised = db.transaction(tx => {
+        throw new Error('Error from callback');
+      });
+
+      // ASSERT: should return a promise that eventually rejects
+      expect(promised).to.have.property('then').that.is.a('function');
+      try {
+        await promised;
+        expect.fail('Should not resolve');
+      } catch (e) {
+        expect(e).to.be.a.instanceof(Error);
+        expect((e as Error)?.message).to.equal('Error from callback');
+      }
+    });
+
+    it('Transaction, rejects on invalid query', async () => {
+      const promised = db.transaction(tx => {
+        console.log('execute bad start');
+        tx.execute('SELECT * FROM [tableThatDoesNotExist];');
+        console.log('execute bad done');
+      });
+
+      // ASSERT: should return a promise that eventually rejects
+      expect(promised).to.have.property('then').that.is.a('function');
+      try {
+        await promised;
+        expect.fail('Should not resolve');
+      } catch (e) {
+        expect(e).to.be.a.instanceof(Error);
+        expect((e as Error)?.message).to.include(
+          'no such table: tableThatDoesNotExist',
+        );
+      }
+    });
+
+    it('Transaction, handle async callback', async () => {
+      let ranCallback = false;
+      const promised = db.transaction(async tx => {
+        await new Promise<void>(done => {
+          setTimeout(() => done(), 50);
+        });
+        tx.execute('SELECT * FROM [User];');
+        ranCallback = true;
+      });
+
+      // ASSERT: should return a promise that eventually rejects
+      expect(promised).to.have.property('then').that.is.a('function');
+      await promised;
+      expect(ranCallback).to.equal(true, 'Should handle async callback');
     });
 
     it('Async transaction, auto commit', async () => {
@@ -304,8 +396,8 @@ export function registerBaseTests() {
         expect(res.insertId).to.equal(1);
         expect(res.metadata).to.eql([]);
         expect(res.rows?._array).to.eql([]);
-        expect(res.rows.length).to.equal(0);
-        expect(res.rows.item).to.be.a('function');
+        expect(res.rows?.length).to.equal(0);
+        expect(res.rows?.item).to.be.a('function');
       });
 
       const res = db.execute('SELECT * FROM User');
@@ -333,11 +425,10 @@ export function registerBaseTests() {
           );
         });
       } catch (error) {
-        expect(error).to.be.instanceOf(Error)
+        expect(error).to.be.instanceOf(Error);
         expect((error as Error).message)
           .to.include('SQL execution error')
-          .and
-          .to.include('cannot store TEXT value in INT column User.id');
+          .and.to.include('cannot store TEXT value in INT column User.id');
 
         const res = db.execute('SELECT * FROM User');
         expect(res.rows?._array).to.eql([]);
@@ -387,10 +478,10 @@ export function registerBaseTests() {
       expect(res.rows?._array).to.eql([]);
     });
 
-    it('Async transaction, upsert and select', async () => {
+    it('Async transaction, executed in order', async () => {
       // ARRANGE: Setup for multiple transactions
       const iterations = 10;
-      const actual = new Set();
+      const actual: unknown[] = [];
 
       // ARRANGE: Generate expected data
       const id = chance.integer();
@@ -400,23 +491,29 @@ export function registerBaseTests() {
       // ACT: Start multiple async transactions to upsert and select the same record
       const promises = [];
       for (let iteration = 1; iteration <= iterations; iteration++) {
-        const promised = db.transactionAsync(async (tx) => {
+        const promised = db.transactionAsync(async tx => {
           // ACT: Upsert statement to create record / increment the value
-          await tx.executeAsync(`
-          INSERT OR REPLACE INTO [User] ([id], [name], [age], [networth])
-          SELECT ?, ?, ?,
-            IFNULL((
-              SELECT [networth] + 1000
-              FROM [User]
-              WHERE [id] = ?
-            ), 1000)
-          `, [id, name, age, id]);
+          await tx.executeAsync(
+            `
+              INSERT OR REPLACE INTO [User] ([id], [name], [age], [networth])
+              SELECT ?, ?, ?,
+                IFNULL((
+                  SELECT [networth] + 1000
+                  FROM [User]
+                  WHERE [id] = ?
+                ), 0)
+          `,
+            [id, name, age, id],
+          );
 
           // ACT: Select statement to get incremented value and store it for checking later
-          const results = await tx.executeAsync('SELECT [networth] FROM [User] WHERE [id] = ?', [id]);
+          const results = await tx.executeAsync(
+            'SELECT [networth] FROM [User] WHERE [id] = ?',
+            [id],
+          );
 
-          actual.add(results.rows._array[0].networth);
-        })
+          actual.push(results.rows?._array[0].networth);
+        });
 
         promises.push(promised);
       }
@@ -425,11 +522,17 @@ export function registerBaseTests() {
       await Promise.all(promises);
 
       // ASSERT: That the expected values where returned
-      expect(actual.size).to.equal(iterations, 'Each transaction should read a different value');
+      const expected = Array(iterations)
+        .fill(0)
+        .map((_, index) => index * 1000);
+      expect(actual).to.eql(
+        expected,
+        'Each transaction should read a different value',
+      );
     });
 
     it('Async transaction, rejects on callback error', async () => {
-      const promised = db.transactionAsync(async (tx) => {
+      const promised = db.transactionAsync(async tx => {
         throw new Error('Error from callback');
       });
 
@@ -445,9 +548,9 @@ export function registerBaseTests() {
     });
 
     it('Async transaction, rejects on invalid query', async () => {
-      const promised = db.transactionAsync(async (tx) => {
+      const promised = db.transactionAsync(async tx => {
         await tx.executeAsync('SELECT * FROM [tableThatDoesNotExist];');
-      })
+      });
 
       // ASSERT: should return a promise that eventually rejects
       expect(promised).to.have.property('then').that.is.a('function');
@@ -456,7 +559,9 @@ export function registerBaseTests() {
         expect.fail('Should not resolve');
       } catch (e) {
         expect(e).to.be.a.instanceof(Error);
-        expect((e as Error)?.message).to.include('no such table: tableThatDoesNotExist');
+        expect((e as Error)?.message).to.include(
+          'no such table: tableThatDoesNotExist',
+        );
       }
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -553,4 +553,3 @@ export const open = (options: {
       QuickSQLite.loadFileAsync(options.name, location),
   };
 };
-///


### PR DESCRIPTION
Notice that the changes in README for previous PR expected transaction to return a Promise<void>. This PR implements that.

This PR contains.
- added Promise returned from `transaction`.
- improved error handling and removing of some unhandled promise rejection messages (see note on PendingTransaction start() method).
- applied prettier formatting to the code changed.